### PR TITLE
Add adaptive stepping (shorter steps when near/hitting clouds)

### DIFF
--- a/addons/SunshineVolumetricClouds/RayMarchedCloudsPost.gdshader
+++ b/addons/SunshineVolumetricClouds/RayMarchedCloudsPost.gdshader
@@ -158,11 +158,31 @@ void fragment() {
 	
 	if (cur_pos.y < SunshineClouds_CloudsFloor && view_dir.y < 0.0 || cur_pos.y > SunshineClouds_CloudsCeiling && view_dir.y > 0.0){discard;}
 	
+	const float hit_step_mult = 0.125;
+	const float near_step_mult = 0.5;
+	bool has_hit = false;
+	float next_step_mult = 1.0;
+	
 	for (int i = 0; i < StepCount; i++) {
-		cur_distance += mix(StepDistanceClose, StepDistanceFar, ease_out_quad(0.0,1.0,float(i) / float(StepCount)));
+		float step_dist = mix(StepDistanceClose, StepDistanceFar, ease_out_quad(0.0,1.0,float(i) / float(StepCount)));
+		step_dist *= has_hit ? hit_step_mult : 1.0;
+		step_dist *= next_step_mult;
+		next_step_mult = 1.0;
+		cur_distance += step_dist;
 		cur_pos = origin + view_dir * cur_distance;
 		
 		thisDensity = samplecloudmap(cur_pos, time)  * CloudDensity;
+		
+		if (thisDensity > DensityCutoff) {
+			if (!has_hit) {
+				has_hit = true;
+				cur_distance -= step_dist * (1.0 - hit_step_mult);
+				continue;
+			}
+		} else if (thisDensity > 0.0) {
+			next_step_mult = near_step_mult;
+		}
+		
 		currentColor = mix(currentColor, SunshineClouds_SunColor.rgb, thisDensity);
 		currentDensity += thisDensity * smoothstep(linear_depth, linear_depth - StepDepthBlendRange, cur_distance);
 		//cutoffvalue = CheckOutOfBounds(cur_pos, view_dir);


### PR DESCRIPTION
Implements a couple forms of adaptive stepping:
- Use smaller steps (0.5x) when near a cloud
  - Greatly reduces shimmering/banding on sparse clouds when using large step sizes
- Use much smaller steps (0.125x) after hitting a cloud
  - Reduces banding, more noticeable up close and on large dense clouds

The improvement is more noticeable with larger step sizes (ie. low quality) & when moving around

I measured very roughly a 2-5% performance hit from this, but I'm on a 4090 so not sure if it's a similar hit on mid-lower end
The boost in quality is worth it for me at least. Of course since the quality is improved that gives some room to lower the number of steps a bit to get that performance back if desired.

(also note I'm not an expert with ray marching or anything so it's possible there's some edge case I didn't think of)

Comparison (low quality: step count=50, step distance=40 near / 150 far):
<details>
<summary>Click to expand</summary>
<br>
Current:

https://github.com/Bonkahe/SunshineClouds/assets/13819558/d9d71ece-ef66-479d-bca8-2cbc53218b3a

Just smaller steps after hitting cloud:

https://github.com/Bonkahe/SunshineClouds/assets/13819558/c2d95baf-9805-4f99-b6f8-376d171c5fc5

Both:

https://github.com/Bonkahe/SunshineClouds/assets/13819558/a7303a00-7bb5-4967-94fe-daf2e6325f66

</details>

(Nice addon btw!)